### PR TITLE
fix: use PAT to bypass branch protection for monthly activity

### DIFF
--- a/.github/workflows/monthly-activity.yaml
+++ b/.github/workflows/monthly-activity.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -20,7 +21,29 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create and push empty commit
+      - name: Create branch with empty commit and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git commit --allow-empty -m "chore: fake activity to GitHub workflows enabled"
-          git push
+          BRANCH_NAME="automated/monthly-activity-$(date +%Y%m)"
+          
+          # Create and switch to new branch
+          git checkout -b "$BRANCH_NAME"
+          
+          # Create empty commit
+          git commit --allow-empty -m "chore: fake activity to keep GitHub workflows enabled"
+          
+          # Push the branch
+          git push -u origin "$BRANCH_NAME"
+          
+          # Create PR
+          PR_URL=$(gh pr create \
+            --title "chore: monthly activity commit ($(date +%B\ %Y))" \
+            --body "Automated monthly activity commit to keep GitHub Actions enabled. This PR was created automatically by the monthly-activity workflow." \
+            --base main \
+            --head "$BRANCH_NAME")
+          
+          echo "Created PR: $PR_URL"
+          
+          # Enable auto-merge (will only work if auto-merge is enabled in repo settings)
+          gh pr merge --auto --squash "$PR_URL" || echo "Auto-merge not available - PR will need manual merge"

--- a/.github/workflows/monthly-activity.yaml
+++ b/.github/workflows/monthly-activity.yaml
@@ -9,41 +9,19 @@ on:
 jobs:
   fake-activity:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Use PAT to authenticate - the PAT owner must be in the branch protection bypass list
+          token: ${{ secrets.ACTIVITY_PAT }}
 
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create branch with empty commit and open PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push empty commit
         run: |
-          BRANCH_NAME="automated/monthly-activity-$(date +%Y%m)"
-          
-          # Create and switch to new branch
-          git checkout -b "$BRANCH_NAME"
-          
-          # Create empty commit
           git commit --allow-empty -m "chore: fake activity to keep GitHub workflows enabled"
-          
-          # Push the branch
-          git push -u origin "$BRANCH_NAME"
-          
-          # Create PR
-          PR_URL=$(gh pr create \
-            --title "chore: monthly activity commit ($(date +%B\ %Y))" \
-            --body "Automated monthly activity commit to keep GitHub Actions enabled. This PR was created automatically by the monthly-activity workflow." \
-            --base main \
-            --head "$BRANCH_NAME")
-          
-          echo "Created PR: $PR_URL"
-          
-          # Enable auto-merge (will only work if auto-merge is enabled in repo settings)
-          gh pr merge --auto --squash "$PR_URL" || echo "Auto-merge not available - PR will need manual merge"
+          git push


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the monthly activity workflow to use a Personal Access Token (PAT) to bypass branch protection rules and push directly to main.

## Setup Required

Before this workflow will work, you need to:

1. **Create a PAT** at https://github.com/settings/tokens
   - Classic token: select `repo` scope
   - Or fine-grained token: select this repo, grant "Contents" read+write

2. **Add yourself to the bypass list**
   - Go to repo Settings → Rules → Rulesets (or Branch protection rules)
   - Edit the rule for `main`
   - Under "Bypass list" or "Allow specified actors to bypass required pull requests", add your GitHub username

3. **Add the PAT as a repo secret**
   - Go to repo Settings → Secrets and variables → Actions
   - Create a new secret named `ACTIVITY_PAT`
   - Paste your PAT as the value

## How it works

The workflow uses `actions/checkout` with your PAT token. When it pushes, GitHub sees the push as coming from you (the PAT owner), and since you're in the bypass list, it's allowed through.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://currentsdev.slack.com/archives/D0946PT2QPQ/p1767960085185409?thread_ts=1767960085.185409&cid=D0946PT2QPQ)

<div><a href="https://cursor.com/agents/bc-881afb2d-7bab-5934-82cc-136c00bc0666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-881afb2d-7bab-5934-82cc-136c00bc0666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

